### PR TITLE
Handle zero-value connection timeout

### DIFF
--- a/internal/protocol/session.go
+++ b/internal/protocol/session.go
@@ -116,8 +116,10 @@ func (c *sessionConn) close() error {
 // Read implements the io.Reader interface.
 func (c *sessionConn) Read(b []byte) (int, error) {
 	//set timeout
-	if err := c.conn.SetReadDeadline(time.Now().Add(c.timeout)); err != nil {
-		return 0, err
+	if c.timeout > 0 {
+		if err := c.conn.SetReadDeadline(time.Now().Add(c.timeout)); err != nil {
+			return 0, err
+		}
 	}
 	n, err := c.conn.Read(b)
 	if err != nil {
@@ -132,8 +134,10 @@ func (c *sessionConn) Read(b []byte) (int, error) {
 // Write implements the io.Writer interface.
 func (c *sessionConn) Write(b []byte) (int, error) {
 	//set timeout
-	if err := c.conn.SetWriteDeadline(time.Now().Add(c.timeout)); err != nil {
-		return 0, err
+	if c.timeout > 0 {
+		if err := c.conn.SetWriteDeadline(time.Now().Add(c.timeout)); err != nil {
+			return 0, err
+		}
 	}
 	n, err := c.conn.Write(b)
 	if err != nil {


### PR DESCRIPTION
Allow operations to run indefinitely if the session's timeout is set to
zero.